### PR TITLE
Include YouTube timestamp in special payload

### DIFF
--- a/src/structs/metadata.rs
+++ b/src/structs/metadata.rs
@@ -172,12 +172,22 @@ impl Metadata {
         }
 
         if let Some(captures) = RE_YOUTUBE.captures_iter(&self.url).next() {
-            if let Some(ogtype) = &self.opengraph_type {
-                if ogtype == "video.other" {
+            lazy_static! {
+                static ref RE_TIMESTAMP: Regex = Regex::new("(?:\\?|&)(?:t|start)=([\\w]+)").unwrap();
+            }
+
+            if let Some(video) = &self.video {
+                if let Some(timestamp_captures) = RE_TIMESTAMP.captures_iter(&video.url).next() {
                     return Ok(Special::YouTube {
                         id: captures[1].to_string(),
+                        timestamp: Some(timestamp_captures[1].to_string()),
                     });
                 }
+
+                return Ok(Special::YouTube {
+                    id: captures[1].to_string(),
+                    timestamp: None,
+                });
             }
         } else if let Some(captures) = RE_TWITCH.captures_iter(&self.url).next() {
                 return Ok(Special::Twitch {

--- a/src/structs/special.rs
+++ b/src/structs/special.rs
@@ -19,6 +19,9 @@ pub enum Special {
     None,
     YouTube {
         id: String,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        timestamp: Option<String>,
     },
     Twitch {
         content_type: TwitchType,


### PR DESCRIPTION
This attempts to fix #2 - will need support in revite to add the timestamp query parameter to the generated embed.